### PR TITLE
chore: simplify state in the shelves demo

### DIFF
--- a/rule-powered-content-shelves-demo/rule-powered-content-shelves/rule-powered-content-shelves.js
+++ b/rule-powered-content-shelves-demo/rule-powered-content-shelves/rule-powered-content-shelves.js
@@ -1,4 +1,7 @@
-const states = {};
+const state = {
+  lastShelvesReceived: null,
+  shelvesIndices: [],
+};
 
 const rulePoweredContentShelves = instantsearch.connectors.connectQueryRules(
   ({ items, widgetParams, instantSearchInstance }) => {
@@ -8,7 +11,6 @@ const rulePoweredContentShelves = instantsearch.connectors.connectQueryRules(
       return;
     }
 
-    const state = getState(widgetParams.container);
     const shelves = items[0].shelves;
     shelves.sort(function(a, b) {
       return a.position - b.position;
@@ -62,14 +64,5 @@ const rulePoweredContentShelves = instantsearch.connectors.connectQueryRules(
     container.append(...shelvesContainers);
   }
 );
-
-function getState(key) {
-  states[key] = states[key] || {
-    lastShelvesReceived: null,
-    shelvesIndices: [],
-  };
-
-  return states[key];
-}
 
 export default rulePoweredContentShelves;


### PR DESCRIPTION
We had `getStates` to manage states per each shelves widget (by using container selector as a key).
However, the current implementation doesn't support users having multiple instances of shelves widgets smoothly. So if we're not going to provide a full support on it, it'd be better just to remove awkward code around it.