### PR TITLE
Fixes imports for CodeSandbox compatibility

### DIFF
--- a/recent-searches-demo/.babelrc
+++ b/recent-searches-demo/.babelrc
@@ -1,0 +1,4 @@
+{   
+  "presets": ["@babel/preset-env"],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
+} 

--- a/recent-searches-demo/index.html
+++ b/recent-searches-demo/index.html
@@ -20,6 +20,8 @@
       href="recent-searches/recent-searches.css"
     />
     <link rel="stylesheet" type="text/css" href="style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.3.3/dist/instantsearch.js"></script>
     <title>Recent Searches</title>
   </head>
 

--- a/recent-searches-demo/package.json
+++ b/recent-searches-demo/package.json
@@ -4,14 +4,19 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "start": "browser-sync start --server --files ."
+    "start": "parcel index.html"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "browser-sync": "^2.18.13"
+    "@babel/core": "^7.8.4",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/preset-env": "^7.8.4",
+    "parcel": "^1.12.4"
   },
   "dependencies": {
+    "algoliasearch": "^4.1.0",
+    "instantsearch.js": "^4.4.0",
     "recent-searches": "^1.0.5"
   }
 }

--- a/recent-searches-demo/recent-searches/recent-searches.js
+++ b/recent-searches-demo/recent-searches/recent-searches.js
@@ -1,11 +1,4 @@
-// You may need to change the import, depending on what build system you use
-// this demo uses browserSync, so we globally assign the library - you probably should not use this
-import * as RecentSearchesGlobalImport from "./../node_modules/recent-searches/dist/index.js";
-
-// Webpack
-// import RecentSearches from "recent-searches"
-
-const RecentSearches = window.RecentSearches.default;
+import RecentSearches from "recent-searches";
 
 const filterUniques = (suggestions, query) => {
   const uniques = suggestions.reduce((acc, suggestion) => {

--- a/recent-searches-demo/sandbox.config.json
+++ b/recent-searches-demo/sandbox.config.json
@@ -1,3 +1,3 @@
 {
-  "template": "static"
+  "template": "parcel"
 }


### PR DESCRIPTION
The use of `browser-sync` caused problems when pushing this demo to CodeSandbox -- it's been updated to use `parcel`.