### PR TITLE
Changed codesandbox to vanilla template

### DIFF
--- a/federated-search-widget-demo/sandbox.config.json
+++ b/federated-search-widget-demo/sandbox.config.json
@@ -1,3 +1,3 @@
 {
-  "template": "static"
+  "template": "vanilla"
 }


### PR DESCRIPTION
The codesandbox wasn't loading correctly with the `static` template, so I changed to `vanilla`.