### PR TITLE
fix: Added warning message when displayed on mobile

### DIFF
--- a/dynamic-facets-positioning-demo/index.html
+++ b/dynamic-facets-positioning-demo/index.html
@@ -42,6 +42,10 @@
         </section>
       </div>
       <div class="container-results">
+        <div class="infobox-container">
+          <b>Please open the page on a larger screen</b> in order to see the
+          sidebar with the facets.
+        </div>
         <header class="container-header container-options no-title">
           <div id="stats-container"></div>
         </header>

--- a/dynamic-facets-positioning-demo/style.css
+++ b/dynamic-facets-positioning-demo/style.css
@@ -91,7 +91,18 @@ html {
     height: 4rem
   }
   
+  .infobox-container {
+    display: none;
+  }
+  
   @media (max-width: 900px) {
+    .infobox-container {
+      display: block;
+      padding: 1rem;
+      border: solid 1px #faebcc;
+      background-color: #fcf8e3;
+    }
+
     .header {
       cursor: pointer;
       background-position: bottom;


### PR DESCRIPTION
When displayed on mobile (or small laptop screen directly on codesandbox), the sidebar with the facets is hidden by default. This might be confusing for people who open it on small resolutions screens. To inform them, a message has been added that invites them to open it on a larger screen.

![image](https://user-images.githubusercontent.com/1101220/114176185-1aff6f00-993b-11eb-8303-cd5927ef8f5f.png)
