### PR TITLE
fix(predictive-search-box): display suggestions when query is uppercased

### DIFF
--- a/predictive-search-box-widget-demo/predictive-search-box/predictive-search-box.js
+++ b/predictive-search-box-widget-demo/predictive-search-box/predictive-search-box.js
@@ -248,11 +248,11 @@ class PredictiveSearchBox {
 
           suggestions = filterUniques(
           recentSearches.concat(response.hits),
-          query
-        ).filter(hit => hit.query.startsWith(query) && hit.query !== query);
+          query.toLowerCase()
+        ).filter(hit => hit.query.startsWith(query.toLowerCase()) && hit.query !== query);
         }else{
           suggestions = response.hits.filter(
-            hit => hit.query.startsWith(query) && hit.query !== query
+            hit => hit.query.startsWith(query.toLowerCase()) && hit.query !== query
           );
         }
 
@@ -262,7 +262,11 @@ class PredictiveSearchBox {
         }
 
         this.predictiveSearchBox.style.display = "flex";
-        this.setPredictiveSearchBoxValue(suggestions[0].query);
+        if (query === query.toUpperCase()) {
+          this.setPredictiveSearchBoxValue(suggestions[0].query.toUpperCase());
+        } else {
+          this.setPredictiveSearchBoxValue(suggestions[0].query);
+        }
         this.tabActionSuggestion = suggestions[0].query;
         return suggestions;
       })


### PR DESCRIPTION
Today typing in uppercase does not display any prediction in the predictive search box solution.
This fixes it.
Demo of working codesandbox with the changes: https://codesandbox.io/s/fast-morning-2c8npq?file=/predictive-search-box/predictive-search-box.js:9166-9375